### PR TITLE
ASM Tree API

### DIFF
--- a/src/main/java/com/rsclauncher/RSCClassLoader.java
+++ b/src/main/java/com/rsclauncher/RSCClassLoader.java
@@ -1,5 +1,6 @@
 package com.rsclauncher;
 
+import com.rsclauncher.patcher.ASMUtils;
 import com.rsclauncher.patcher.ClassPatcher;
 import com.rsclauncher.patcher.ClientPatcher;
 import com.rsclauncher.patcher.GameCharacterPatcher;
@@ -55,7 +56,7 @@ public class RSCClassLoader extends ClassLoader {
 
         final ClassNode newClassNode;
         if (patcher != null) {
-          newClassNode = patcher.patch(classNode);
+          newClassNode = patcher.patch(ASMUtils.copyClassNode(classNode));
         } else {
           newClassNode = classNode;
         }

--- a/src/main/java/com/rsclauncher/patcher/ASMUtils.java
+++ b/src/main/java/com/rsclauncher/patcher/ASMUtils.java
@@ -1,0 +1,14 @@
+package com.rsclauncher.patcher;
+
+import org.objectweb.asm.tree.ClassNode;
+
+public class ASMUtils {
+
+  public static ClassNode copyClassNode(ClassNode originalClassNode) {
+    ClassNode newClassNode = new ClassNode();
+    originalClassNode.accept(newClassNode);
+
+    return newClassNode;
+  }
+
+}

--- a/src/main/java/com/rsclauncher/patcher/ClassAnalyzer.java
+++ b/src/main/java/com/rsclauncher/patcher/ClassAnalyzer.java
@@ -1,0 +1,4 @@
+package com.rsclauncher.patcher;
+
+public class ClassAnalyzer {
+}

--- a/src/main/java/com/rsclauncher/patcher/ClassPatcher.java
+++ b/src/main/java/com/rsclauncher/patcher/ClassPatcher.java
@@ -2,6 +2,7 @@ package com.rsclauncher.patcher;
 
 import org.objectweb.asm.tree.ClassNode;
 
+// TODO: Can possibly compose chains of ClassPatchers
 public abstract class ClassPatcher {
 
   public abstract ClassNode patch(ClassNode classNode);

--- a/src/main/java/com/rsclauncher/patcher/ClassPatcher.java
+++ b/src/main/java/com/rsclauncher/patcher/ClassPatcher.java
@@ -1,0 +1,9 @@
+package com.rsclauncher.patcher;
+
+import org.objectweb.asm.tree.ClassNode;
+
+public abstract class ClassPatcher {
+
+  public abstract ClassNode patch(ClassNode classNode);
+
+}

--- a/src/main/java/com/rsclauncher/patcher/ClientPatcher.java
+++ b/src/main/java/com/rsclauncher/patcher/ClientPatcher.java
@@ -1,11 +1,10 @@
 package com.rsclauncher.patcher;
 
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.tree.*;
 
 import static org.objectweb.asm.Opcodes.*;
 
-public class ClientPatcher extends ClassVisitor {
+public class ClientPatcher extends ClassPatcher {
 
   private static final String O_CLASS_NAME = "client";
   private static final String O_GET_LOCAL_REGION_X = "kk";
@@ -20,140 +19,101 @@ public class ClientPatcher extends ClassVisitor {
   private static final String O_GET_NEARBY_PLAYERS = "Nj";
   private static final String O_GET_NPCS = "Rg";
 
-  public ClientPatcher(int i, ClassVisitor cv) {
-    super(i, cv);
-  }
-
   @Override
-  public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-    final String[] newInterfaces = new String[] { "com/rsclauncher/api/Client" };
+  public ClassNode patch(ClassNode classNode) {
+    ClassNode newClassNode = ASMUtils.copyClassNode(classNode);
 
-    cv.visit(version, access, name, signature, superName, newInterfaces);
-  }
+    newClassNode.interfaces.add("com/rsclauncher/api/Client");
 
-  @Override
-  public void visitEnd() {
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getRegionX", "()I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_REGION_X, "I");
-      mv.visitInsn(IRETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getRegionX = new MethodNode(ACC_PUBLIC, "getRegionX", "()I", null, null);
+    getRegionX.instructions.add(new VarInsnNode(ALOAD, 0));
+    getRegionX.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_REGION_X, "I"));
+    getRegionX.instructions.add(new InsnNode(IRETURN));
+    getRegionX.maxStack = 2;
+    getRegionX.maxLocals = 1;
+    newClassNode.methods.add(getRegionX);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getRegionY", "()I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_REGION_Y, "I");
-      mv.visitInsn(IRETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getRegionY = new MethodNode(ACC_PUBLIC, "getRegionY", "()I", null, null);
+    getRegionY.instructions.add(new VarInsnNode(ALOAD, 0));
+    getRegionY.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_REGION_Y, "I"));
+    getRegionY.instructions.add(new InsnNode(IRETURN));
+    getRegionY.maxStack = 2;
+    getRegionY.maxLocals = 1;
+    newClassNode.methods.add(getRegionY);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getLocalRegionX", "()I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_LOCAL_REGION_X, "I");
-      mv.visitInsn(IRETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getLocalRegionX = new MethodNode(ACC_PUBLIC, "getLocalRegionX", "()I", null, null);
+    getLocalRegionX.instructions.add(new VarInsnNode(ALOAD, 0));
+    getLocalRegionX.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_LOCAL_REGION_X, "I"));
+    getLocalRegionX.instructions.add(new InsnNode(IRETURN));
+    getLocalRegionX.maxStack = 2;
+    getLocalRegionX.maxLocals = 1;
+    newClassNode.methods.add(getLocalRegionX);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getLocalRegionY", "()I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_LOCAL_REGION_Y, "I");
-      mv.visitInsn(IRETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getLocalRegionY = new MethodNode(ACC_PUBLIC, "getLocalRegionY", "()I", null, null);
+    getLocalRegionY.instructions.add(new VarInsnNode(ALOAD, 0));
+    getLocalRegionY.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_LOCAL_REGION_Y, "I"));
+    getLocalRegionY.instructions.add(new InsnNode(IRETURN));
+    getLocalRegionY.maxStack = 2;
+    getLocalRegionY.maxLocals = 1;
+    newClassNode.methods.add(getLocalRegionY);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getQuestNames", "()[Ljava/lang/String;", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_QUEST_NAMES, "[Ljava/lang/String;");
-      mv.visitInsn(ARETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getQuestNames = new MethodNode(ACC_PUBLIC, "getQuestNames", "()[Ljava/lang/String;", null, null);
+    getQuestNames.instructions.add(new VarInsnNode(ALOAD, 0));
+    getQuestNames.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_QUEST_NAMES, "[Ljava/lang/String;"));
+    getQuestNames.instructions.add(new InsnNode(ARETURN));
+    getQuestNames.maxStack = 2;
+    getQuestNames.maxLocals = 1;
+    newClassNode.methods.add(getQuestNames);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getSkillNames", "()[Ljava/lang/String;", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_SKILL_NAMES, "[Ljava/lang/String;");
-      mv.visitInsn(ARETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getSkillNames = new MethodNode(ACC_PUBLIC, "getSkillNames", "()[Ljava/lang/String;", null, null);
+    getSkillNames.instructions.add(new VarInsnNode(ALOAD, 0));
+    getSkillNames.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_SKILL_NAMES, "[Ljava/lang/String;"));
+    getSkillNames.instructions.add(new InsnNode(ARETURN));
+    getSkillNames.maxStack = 2;
+    getSkillNames.maxLocals = 1;
+    newClassNode.methods.add(getSkillNames);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getSkillLevels", "()[I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_SKILL_LEVELS, "[I");
-      mv.visitInsn(ARETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getSkillLevels = new MethodNode(ACC_PUBLIC, "getSkillLevels", "()[I", null, null);
+    getSkillLevels.instructions.add(new VarInsnNode(ALOAD, 0));
+    getSkillLevels.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_SKILL_LEVELS, "[I"));
+    getSkillLevels.instructions.add(new InsnNode(ARETURN));
+    getSkillLevels.maxStack = 2;
+    getSkillLevels.maxLocals = 1;
+    newClassNode.methods.add(getSkillLevels);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getSkillExperiences", "()[I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_SKILL_EXPERIENCES, "[I");
-      mv.visitInsn(ARETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getSkillExperiences = new MethodNode(ACC_PUBLIC, "getSkillExperiences", "()[I", null, null);
+    getSkillExperiences.instructions.add(new VarInsnNode(ALOAD, 0));
+    getSkillExperiences.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_SKILL_EXPERIENCES, "[I"));
+    getSkillExperiences.instructions.add(new InsnNode(ARETURN));
+    getSkillExperiences.maxStack = 2;
+    getSkillExperiences.maxLocals = 1;
+    newClassNode.methods.add(getSkillExperiences);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getLocalPlayer", "()Lcom/rsclauncher/api/GameCharacter;", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_LOCAL_PLAYER, "Lnb;");
-      mv.visitInsn(ARETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getLocalPlayer = new MethodNode(ACC_PUBLIC, "getLocalPlayer", "()Lcom/rsclauncher/api/GameCharacter;", null, null);
+    getLocalPlayer.instructions.add(new VarInsnNode(ALOAD, 0));
+    getLocalPlayer.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_LOCAL_PLAYER, "Lnb;"));
+    getLocalPlayer.instructions.add(new InsnNode(ARETURN));
+    getLocalPlayer.maxStack = 2;
+    getLocalPlayer.maxLocals = 1;
+    newClassNode.methods.add(getLocalPlayer);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getNearbyPlayers", "()[Lcom/rsclauncher/api/GameCharacter;", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_NEARBY_PLAYERS, "[Lnb;");
-      mv.visitInsn(ARETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getNearbyPlayers = new MethodNode(ACC_PUBLIC, "getNearbyPlayers", "()[Lcom/rsclauncher/api/GameCharacter;", null, null);
+    getNearbyPlayers.instructions.add(new VarInsnNode(ALOAD, 0));
+    getNearbyPlayers.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_NEARBY_PLAYERS, "[Lnb;"));
+    getNearbyPlayers.instructions.add(new InsnNode(ARETURN));
+    getNearbyPlayers.maxStack = 2;
+    getNearbyPlayers.maxLocals = 1;
+    newClassNode.methods.add(getNearbyPlayers);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getNpcs", "()[Lcom/rsclauncher/api/GameCharacter;", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD,  O_CLASS_NAME, O_GET_NPCS, "[Lnb;");
-      mv.visitInsn(ARETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getNpcs = new MethodNode(ACC_PUBLIC, "getNpcs", "()[Lcom/rsclauncher/api/GameCharacter;", null, null);
+    getNpcs.instructions.add(new VarInsnNode(ALOAD, 0));
+    getNpcs.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_NPCS, "[Lnb;"));
+    getNpcs.instructions.add(new InsnNode(ARETURN));
+    getNpcs.maxStack = 2;
+    getNpcs.maxLocals = 1;
+    newClassNode.methods.add(getNpcs);
 
-//    {
-//      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getEquippedItems", "()[I", null, null);
-//      mv.visitCode();
-//      mv.visitVarInsn(ALOAD, 0);
-//      mv.visitFieldInsn(GETFIELD, "client", "l", "[I");
-//      mv.visitInsn(IRETURN);
-//      mv.visitMaxs(2, 1);
-//      mv.visitEnd();
-//    }
-
-    cv.visitEnd();
+    return newClassNode;
   }
 
 }

--- a/src/main/java/com/rsclauncher/patcher/ClientPatcher.java
+++ b/src/main/java/com/rsclauncher/patcher/ClientPatcher.java
@@ -21,9 +21,7 @@ public class ClientPatcher extends ClassPatcher {
 
   @Override
   public ClassNode patch(ClassNode classNode) {
-    ClassNode newClassNode = ASMUtils.copyClassNode(classNode);
-
-    newClassNode.interfaces.add("com/rsclauncher/api/Client");
+    classNode.interfaces.add("com/rsclauncher/api/Client");
 
     MethodNode getRegionX = new MethodNode(ACC_PUBLIC, "getRegionX", "()I", null, null);
     getRegionX.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -31,7 +29,7 @@ public class ClientPatcher extends ClassPatcher {
     getRegionX.instructions.add(new InsnNode(IRETURN));
     getRegionX.maxStack = 2;
     getRegionX.maxLocals = 1;
-    newClassNode.methods.add(getRegionX);
+    classNode.methods.add(getRegionX);
 
     MethodNode getRegionY = new MethodNode(ACC_PUBLIC, "getRegionY", "()I", null, null);
     getRegionY.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -39,7 +37,7 @@ public class ClientPatcher extends ClassPatcher {
     getRegionY.instructions.add(new InsnNode(IRETURN));
     getRegionY.maxStack = 2;
     getRegionY.maxLocals = 1;
-    newClassNode.methods.add(getRegionY);
+    classNode.methods.add(getRegionY);
 
     MethodNode getLocalRegionX = new MethodNode(ACC_PUBLIC, "getLocalRegionX", "()I", null, null);
     getLocalRegionX.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -47,7 +45,7 @@ public class ClientPatcher extends ClassPatcher {
     getLocalRegionX.instructions.add(new InsnNode(IRETURN));
     getLocalRegionX.maxStack = 2;
     getLocalRegionX.maxLocals = 1;
-    newClassNode.methods.add(getLocalRegionX);
+    classNode.methods.add(getLocalRegionX);
 
     MethodNode getLocalRegionY = new MethodNode(ACC_PUBLIC, "getLocalRegionY", "()I", null, null);
     getLocalRegionY.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -55,7 +53,7 @@ public class ClientPatcher extends ClassPatcher {
     getLocalRegionY.instructions.add(new InsnNode(IRETURN));
     getLocalRegionY.maxStack = 2;
     getLocalRegionY.maxLocals = 1;
-    newClassNode.methods.add(getLocalRegionY);
+    classNode.methods.add(getLocalRegionY);
 
     MethodNode getQuestNames = new MethodNode(ACC_PUBLIC, "getQuestNames", "()[Ljava/lang/String;", null, null);
     getQuestNames.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -63,7 +61,7 @@ public class ClientPatcher extends ClassPatcher {
     getQuestNames.instructions.add(new InsnNode(ARETURN));
     getQuestNames.maxStack = 2;
     getQuestNames.maxLocals = 1;
-    newClassNode.methods.add(getQuestNames);
+    classNode.methods.add(getQuestNames);
 
     MethodNode getSkillNames = new MethodNode(ACC_PUBLIC, "getSkillNames", "()[Ljava/lang/String;", null, null);
     getSkillNames.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -71,7 +69,7 @@ public class ClientPatcher extends ClassPatcher {
     getSkillNames.instructions.add(new InsnNode(ARETURN));
     getSkillNames.maxStack = 2;
     getSkillNames.maxLocals = 1;
-    newClassNode.methods.add(getSkillNames);
+    classNode.methods.add(getSkillNames);
 
     MethodNode getSkillLevels = new MethodNode(ACC_PUBLIC, "getSkillLevels", "()[I", null, null);
     getSkillLevels.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -79,7 +77,7 @@ public class ClientPatcher extends ClassPatcher {
     getSkillLevels.instructions.add(new InsnNode(ARETURN));
     getSkillLevels.maxStack = 2;
     getSkillLevels.maxLocals = 1;
-    newClassNode.methods.add(getSkillLevels);
+    classNode.methods.add(getSkillLevels);
 
     MethodNode getSkillExperiences = new MethodNode(ACC_PUBLIC, "getSkillExperiences", "()[I", null, null);
     getSkillExperiences.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -87,7 +85,7 @@ public class ClientPatcher extends ClassPatcher {
     getSkillExperiences.instructions.add(new InsnNode(ARETURN));
     getSkillExperiences.maxStack = 2;
     getSkillExperiences.maxLocals = 1;
-    newClassNode.methods.add(getSkillExperiences);
+    classNode.methods.add(getSkillExperiences);
 
     MethodNode getLocalPlayer = new MethodNode(ACC_PUBLIC, "getLocalPlayer", "()Lcom/rsclauncher/api/GameCharacter;", null, null);
     getLocalPlayer.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -95,7 +93,7 @@ public class ClientPatcher extends ClassPatcher {
     getLocalPlayer.instructions.add(new InsnNode(ARETURN));
     getLocalPlayer.maxStack = 2;
     getLocalPlayer.maxLocals = 1;
-    newClassNode.methods.add(getLocalPlayer);
+    classNode.methods.add(getLocalPlayer);
 
     MethodNode getNearbyPlayers = new MethodNode(ACC_PUBLIC, "getNearbyPlayers", "()[Lcom/rsclauncher/api/GameCharacter;", null, null);
     getNearbyPlayers.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -103,7 +101,7 @@ public class ClientPatcher extends ClassPatcher {
     getNearbyPlayers.instructions.add(new InsnNode(ARETURN));
     getNearbyPlayers.maxStack = 2;
     getNearbyPlayers.maxLocals = 1;
-    newClassNode.methods.add(getNearbyPlayers);
+    classNode.methods.add(getNearbyPlayers);
 
     MethodNode getNpcs = new MethodNode(ACC_PUBLIC, "getNpcs", "()[Lcom/rsclauncher/api/GameCharacter;", null, null);
     getNpcs.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -111,9 +109,9 @@ public class ClientPatcher extends ClassPatcher {
     getNpcs.instructions.add(new InsnNode(ARETURN));
     getNpcs.maxStack = 2;
     getNpcs.maxLocals = 1;
-    newClassNode.methods.add(getNpcs);
+    classNode.methods.add(getNpcs);
 
-    return newClassNode;
+    return classNode;
   }
 
 }

--- a/src/main/java/com/rsclauncher/patcher/GameCharacterPatcher.java
+++ b/src/main/java/com/rsclauncher/patcher/GameCharacterPatcher.java
@@ -1,11 +1,10 @@
 package com.rsclauncher.patcher;
 
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.tree.*;
 
 import static org.objectweb.asm.Opcodes.*;
 
-public class GameCharacterPatcher extends ClassVisitor {
+public class GameCharacterPatcher extends ClassPatcher {
 
   private static final String O_CLASS_NAME = "nb";
   private static final String O_GET_NAME = "d";
@@ -17,100 +16,77 @@ public class GameCharacterPatcher extends ClassVisitor {
   private static final String O_GET_EQUIPPED_ITEMS = "l";
   private static final String O_GET_OVERHEAD_MESSAGE = "q";
 
-  public GameCharacterPatcher(int i, ClassVisitor cv) {
-    super(i, cv);
-  }
-
   @Override
-  public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-    final String[] newInterfaces = new String[] { "com/rsclauncher/api/GameCharacter" };
+  public ClassNode patch(ClassNode classNode) {
+    ClassNode newClassNode = ASMUtils.copyClassNode(classNode);
 
-    cv.visit(version, access, name, signature, superName, newInterfaces);
-  }
+    newClassNode.interfaces.add("com/rsclauncher/api/GameCharacter");
 
-  @Override
-  public void visitEnd() {
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getName", "()Ljava/lang/String;", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME,  O_GET_NAME, "Ljava/lang/String;");
-      mv.visitInsn(ARETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getName = new MethodNode(ACC_PUBLIC, "getRegionX", "()Ljava/lang/String;", null, null);
+    getName.instructions.add(new VarInsnNode(ALOAD, 0));
+    getName.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_NAME, "Ljava/lang/String;"));
+    getName.instructions.add(new InsnNode(ARETURN));
+    getName.maxStack = 2;
+    getName.maxLocals = 1;
+    newClassNode.methods.add(getName);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getCurrentHealth", "()I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_CURRENT_HEALTH, "I");
-      mv.visitInsn(IRETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getCurrentHealth = new MethodNode(ACC_PUBLIC, "getCurrentHealth", "()I", null, null);
+    getCurrentHealth.instructions.add(new VarInsnNode(ALOAD, 0));
+    getCurrentHealth.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_CURRENT_HEALTH, "I"));
+    getCurrentHealth.instructions.add(new InsnNode(IRETURN));
+    getCurrentHealth.maxStack = 2;
+    getCurrentHealth.maxLocals = 1;
+    newClassNode.methods.add(getCurrentHealth);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getMaxHealth", "()I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_MAX_HEALTH, "I");
-      mv.visitInsn(IRETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getMaxHealth = new MethodNode(ACC_PUBLIC, "getMaxHealth", "()I", null, null);
+    getMaxHealth.instructions.add(new VarInsnNode(ALOAD, 0));
+    getMaxHealth.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_MAX_HEALTH, "I"));
+    getMaxHealth.instructions.add(new InsnNode(IRETURN));
+    getMaxHealth.maxStack = 2;
+    getMaxHealth.maxLocals = 1;
+    newClassNode.methods.add(getMaxHealth);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getCombatLevel", "()I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_COMBAT_LEVEL, "I");
-      mv.visitInsn(IRETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getCombatLevel = new MethodNode(ACC_PUBLIC, "getCombatLevel", "()I", null, null);
+    getCombatLevel.instructions.add(new VarInsnNode(ALOAD, 0));
+    getCombatLevel.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_COMBAT_LEVEL, "I"));
+    getCombatLevel.instructions.add(new InsnNode(IRETURN));
+    getCombatLevel.maxStack = 2;
+    getCombatLevel.maxLocals = 1;
+    newClassNode.methods.add(getCombatLevel);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getDamageTaken", "()I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_DAMAGE_TAKEN, "I");
-      mv.visitInsn(IRETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getDamageTaken = new MethodNode(ACC_PUBLIC, "getDamageTaken", "()I", null, null);
+    getDamageTaken.instructions.add(new VarInsnNode(ALOAD, 0));
+    getDamageTaken.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_DAMAGE_TAKEN, "I"));
+    getDamageTaken.instructions.add(new InsnNode(IRETURN));
+    getDamageTaken.maxStack = 2;
+    getDamageTaken.maxLocals = 1;
+    newClassNode.methods.add(getDamageTaken);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getNpcId", "()I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_NPC_ID, "I");
-      mv.visitInsn(IRETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getNpcId = new MethodNode(ACC_PUBLIC, "getNpcId", "()I", null, null);
+    getNpcId.instructions.add(new VarInsnNode(ALOAD, 0));
+    getNpcId.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_NPC_ID, "I"));
+    getNpcId.instructions.add(new InsnNode(IRETURN));
+    getNpcId.maxStack = 2;
+    getNpcId.maxLocals = 1;
+    newClassNode.methods.add(getNpcId);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getEquippedItems", "()[I", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_EQUIPPED_ITEMS, "[I");
-      mv.visitInsn(ARETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getEquippedItems = new MethodNode(ACC_PUBLIC, "getEquippedItems", "()[I", null, null);
+    getEquippedItems.instructions.add(new VarInsnNode(ALOAD, 0));
+    getEquippedItems.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_EQUIPPED_ITEMS, "[I"));
+    getEquippedItems.instructions.add(new InsnNode(ARETURN));
+    getEquippedItems.maxStack = 2;
+    getEquippedItems.maxLocals = 1;
+    newClassNode.methods.add(getEquippedItems);
 
-    {
-      final MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "getOverheadMessage", "()Ljava/lang/String;", null, null);
-      mv.visitCode();
-      mv.visitVarInsn(ALOAD, 0);
-      mv.visitFieldInsn(GETFIELD, O_CLASS_NAME, O_GET_OVERHEAD_MESSAGE, "Ljava/lang/String;");
-      mv.visitInsn(ARETURN);
-      mv.visitMaxs(2, 1);
-      mv.visitEnd();
-    }
+    MethodNode getOverheadMessage = new MethodNode(ACC_PUBLIC, "getOverheadMessage", "()Ljava/lang/String;", null, null);
+    getOverheadMessage.instructions.add(new VarInsnNode(ALOAD, 0));
+    getOverheadMessage.instructions.add(new FieldInsnNode(GETFIELD, O_CLASS_NAME, O_GET_OVERHEAD_MESSAGE, "Ljava/lang/String;"));
+    getOverheadMessage.instructions.add(new InsnNode(ARETURN));
+    getOverheadMessage.maxStack = 2;
+    getOverheadMessage.maxLocals = 1;
+    newClassNode.methods.add(getOverheadMessage);
 
-    cv.visitEnd();
+    return newClassNode;
   }
 
 }

--- a/src/main/java/com/rsclauncher/patcher/GameCharacterPatcher.java
+++ b/src/main/java/com/rsclauncher/patcher/GameCharacterPatcher.java
@@ -18,9 +18,7 @@ public class GameCharacterPatcher extends ClassPatcher {
 
   @Override
   public ClassNode patch(ClassNode classNode) {
-    ClassNode newClassNode = ASMUtils.copyClassNode(classNode);
-
-    newClassNode.interfaces.add("com/rsclauncher/api/GameCharacter");
+    classNode.interfaces.add("com/rsclauncher/api/GameCharacter");
 
     MethodNode getName = new MethodNode(ACC_PUBLIC, "getRegionX", "()Ljava/lang/String;", null, null);
     getName.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -28,7 +26,7 @@ public class GameCharacterPatcher extends ClassPatcher {
     getName.instructions.add(new InsnNode(ARETURN));
     getName.maxStack = 2;
     getName.maxLocals = 1;
-    newClassNode.methods.add(getName);
+    classNode.methods.add(getName);
 
     MethodNode getCurrentHealth = new MethodNode(ACC_PUBLIC, "getCurrentHealth", "()I", null, null);
     getCurrentHealth.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -36,7 +34,7 @@ public class GameCharacterPatcher extends ClassPatcher {
     getCurrentHealth.instructions.add(new InsnNode(IRETURN));
     getCurrentHealth.maxStack = 2;
     getCurrentHealth.maxLocals = 1;
-    newClassNode.methods.add(getCurrentHealth);
+    classNode.methods.add(getCurrentHealth);
 
     MethodNode getMaxHealth = new MethodNode(ACC_PUBLIC, "getMaxHealth", "()I", null, null);
     getMaxHealth.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -44,7 +42,7 @@ public class GameCharacterPatcher extends ClassPatcher {
     getMaxHealth.instructions.add(new InsnNode(IRETURN));
     getMaxHealth.maxStack = 2;
     getMaxHealth.maxLocals = 1;
-    newClassNode.methods.add(getMaxHealth);
+    classNode.methods.add(getMaxHealth);
 
     MethodNode getCombatLevel = new MethodNode(ACC_PUBLIC, "getCombatLevel", "()I", null, null);
     getCombatLevel.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -52,7 +50,7 @@ public class GameCharacterPatcher extends ClassPatcher {
     getCombatLevel.instructions.add(new InsnNode(IRETURN));
     getCombatLevel.maxStack = 2;
     getCombatLevel.maxLocals = 1;
-    newClassNode.methods.add(getCombatLevel);
+    classNode.methods.add(getCombatLevel);
 
     MethodNode getDamageTaken = new MethodNode(ACC_PUBLIC, "getDamageTaken", "()I", null, null);
     getDamageTaken.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -60,7 +58,7 @@ public class GameCharacterPatcher extends ClassPatcher {
     getDamageTaken.instructions.add(new InsnNode(IRETURN));
     getDamageTaken.maxStack = 2;
     getDamageTaken.maxLocals = 1;
-    newClassNode.methods.add(getDamageTaken);
+    classNode.methods.add(getDamageTaken);
 
     MethodNode getNpcId = new MethodNode(ACC_PUBLIC, "getNpcId", "()I", null, null);
     getNpcId.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -68,7 +66,7 @@ public class GameCharacterPatcher extends ClassPatcher {
     getNpcId.instructions.add(new InsnNode(IRETURN));
     getNpcId.maxStack = 2;
     getNpcId.maxLocals = 1;
-    newClassNode.methods.add(getNpcId);
+    classNode.methods.add(getNpcId);
 
     MethodNode getEquippedItems = new MethodNode(ACC_PUBLIC, "getEquippedItems", "()[I", null, null);
     getEquippedItems.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -76,7 +74,7 @@ public class GameCharacterPatcher extends ClassPatcher {
     getEquippedItems.instructions.add(new InsnNode(ARETURN));
     getEquippedItems.maxStack = 2;
     getEquippedItems.maxLocals = 1;
-    newClassNode.methods.add(getEquippedItems);
+    classNode.methods.add(getEquippedItems);
 
     MethodNode getOverheadMessage = new MethodNode(ACC_PUBLIC, "getOverheadMessage", "()Ljava/lang/String;", null, null);
     getOverheadMessage.instructions.add(new VarInsnNode(ALOAD, 0));
@@ -84,9 +82,9 @@ public class GameCharacterPatcher extends ClassPatcher {
     getOverheadMessage.instructions.add(new InsnNode(ARETURN));
     getOverheadMessage.maxStack = 2;
     getOverheadMessage.maxLocals = 1;
-    newClassNode.methods.add(getOverheadMessage);
+    classNode.methods.add(getOverheadMessage);
 
-    return newClassNode;
+    return classNode;
   }
 
 }


### PR DESCRIPTION
Previously, we were using ASM's event-based API to both analyze and inject code to classes. Some drawbacks to the event-based API include:
- It is difficult to inject instructions into existing methods
- It is difficult to analyze a class and produce some sort of meaningful result (pass in an object and mutate it)
- It is difficult to compose many Visitors

This PR includes a conversion from the event-based API to the tree-based API, where we can operate on entities in the bytecode via a regular Java object. The API is (needlessly) mutable, but we can isolate modifications to nodes. 

Most importantly, this should make it easier to hook into existing methods without having to rewrite the entire method's bytecode. We can also create some abstraction to facilitate composition (we can combine patchers that logs info about a class, injects code into methods to print its arguments, adds a particular method, etc). This should also pave the way for deduplicating some of the code generation.